### PR TITLE
Added matching based on HTTP method

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Thanks to the [rack-attack](https://github.com/kickstarter/rack-attack) gem for 
 * rules matched top to bottom
 
 * what to fail?
-  * REQUEST_METHODs
-  * PATH_INFO equal, regex
   * block which takes rack env
 
 * when to fail?
@@ -59,7 +57,7 @@ Thanks to the [rack-attack](https://github.com/kickstarter/rack-attack) gem for 
 
 ```ruby
 Rack::Wreck.rules do
-  rule "/login", chance: 0.1,  status: 500
+  rule "/login", method: :post, chance: 0.1,  status: 500
   rule /widget/, chance: 0.05, status: 403, body: "Nice try!" 
 end
 ```

--- a/lib/rack/wreck.rb
+++ b/lib/rack/wreck.rb
@@ -21,7 +21,7 @@ module Rack
 
     def call(env)
       matching_rule = self.class.rules.detect do |r|
-        r.match(env["PATH_INFO"])
+        r.match(env)
       end
 
       if matching_rule

--- a/spec/rack/wreck/rule_spec.rb
+++ b/spec/rack/wreck/rule_spec.rb
@@ -5,16 +5,22 @@ require_relative "../../../lib/rack/wreck/rule"
 describe "rule" do
   describe "matching" do
     it "matches string" do
-      assert Rack::Wreck::Rule.new("/foo").match("/foo")
-      refute Rack::Wreck::Rule.new("/foo").match("/bar")
-      refute Rack::Wreck::Rule.new("/foo").match("/")
+      assert Rack::Wreck::Rule.new("/foo").match("PATH_INFO" => "/foo")
+      refute Rack::Wreck::Rule.new("/foo").match("PATH_INFO" => "/bar")
+      refute Rack::Wreck::Rule.new("/foo").match("PATH_INFO" => "/")
     end
 
     it "matches regex" do
-      assert Rack::Wreck::Rule.new(/foo/).match("/foo/bar")
-      assert Rack::Wreck::Rule.new(/foo/).match("/bar/foo/bar")
-      assert Rack::Wreck::Rule.new(/foo/).match("/bar/foo")
-      refute Rack::Wreck::Rule.new(/foo/).match("/bar")
+      assert Rack::Wreck::Rule.new(/foo/).match("PATH_INFO" => "/foo/bar")
+      assert Rack::Wreck::Rule.new(/foo/).match("PATH_INFO" => "/bar/foo/bar")
+      assert Rack::Wreck::Rule.new(/foo/).match("PATH_INFO" => "/bar/foo")
+      refute Rack::Wreck::Rule.new(/foo/).match("PATH_INFO" => "/bar")
+    end
+
+    it "matches HTTP method" do
+      assert Rack::Wreck::Rule.new("/", method: :get).match("REQUEST_METHOD" => "GET", "PATH_INFO" => "/")
+      refute Rack::Wreck::Rule.new("/", method: :post).match("REQUEST_METHOD" => "GET", "PATH_INFO" => "/")
+      refute Rack::Wreck::Rule.new("/", method: :get).match("REQUEST_METHOD" => "POST", "PATH_INFO" => "/")
     end
   end
 
@@ -63,6 +69,11 @@ describe "rule" do
     it "when path is regex" do
       rule = Rack::Wreck::Rule.new(/matchme/, chance: 0.4, status: 403, body: "such fail")
       assert_equal 'rule /matchme/, chance: 0.4, status: 403, body: "such fail"', rule.to_s
+    end
+
+    it "includes method" do
+      rule = Rack::Wreck::Rule.new("path", chance: 0.4, status: 403, method: :post)
+      assert_equal 'rule "path", method: :post, chance: 0.4, status: 403, body: ""', rule.to_s
     end
   end
 end


### PR DESCRIPTION
One my want to have a rule which matches `POST`s, but not `GET`s, for a particular endpoint.